### PR TITLE
Ensure parent post doesn't have it's date updated on new release

### DIFF
--- a/scripts/wordpress-update.js
+++ b/scripts/wordpress-update.js
@@ -16,6 +16,13 @@ process.on( "uncaughtException", function( error ) {
 function isStable( version ) {
 	return (/^\d+\.\d+\.\d+$/).test( version );
 }
+function extend( a, b ) {
+	for ( var p in b ) {
+		a[ p ] = b[ p ];
+	}
+
+	return a;
+}
 
 var actions = {};
 
@@ -134,7 +141,10 @@ actions.addRelease = function( data, fn ) {
 			// main page is constructed from the new version since pretty much
 			// anything can change between versions.
 			if ( versions.latest === manifest.version ) {
-				mainPage = Object.create( pageDetails );
+				extend( mainPage, pageDetails );
+				// don't update the post date on main page, and let it be set
+				// to whenever we processed it, no harm here.
+				delete mainPage.date;
 				mainPage.name = manifest.name;
 				mainPage.customFields = mergeCustomFields(
 					existingCustomFields, pageDetails.customFields );


### PR DESCRIPTION
Currently, every time a new release happens, the parent post's date is updated by the wordpress sync task.  This shouldn't happen, and as soon as this is fixed, I think our queries that look for "New Plugins" vs "Updated Plugins" should be fixed.  This should close #76 
